### PR TITLE
feat: support multiple Java file selection and French translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ### Added
 
+- Support for selecting multiple Java files in IntelliJ IDEA project panel.
+- New keyboard shortcut: <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd> to invoke the plugin. Instead of <kbd>
+  Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd>.
+- Enhanced UI with root files highlighted in orange.
+- Introduce French translations.
+
+### Fixed
+
+- Enhanced plugin Usage instructions in `README.md`.
+
+## [0.0.1]
+
+### Added
+
 - Initial version
 - Initial scaffold created
   from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ visual representation of the dependencies, enabling users to explore and manipul
 
 ## Usage
 
-1. **Open a Java file** in IntelliJ IDEA.
-2. **Invoke the plugin** using the configured shortcut.
+1. **Select one or multiples Java file** in IntelliJ IDEA project side panel.
+2. **Invoke the plugin** using the configured shortcut (default <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd>).
+    - Or use the Command Palette (Find Action, <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd>) then type <kbd>
+      CodeGraph - Show Dependencies</kbd>.
 3. **Enter an optional package filter** in the prompt.
 4. The **dependency graph is displayed** in a floating window.
 5. **Interact with the graph**:
-
-- Click nodes to enable/disable them to include/exclude files from concatenation.
-
+    - Click nodes to enable/disable them to include/exclude files from concatenation.
 6. Click **“Concatenate to Clipboard”** to copy the selected files’ content.
 7. **Paste the concatenated content** where needed (ChatGPT, Claude, Ollama, etc.).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.sisimomo.codegraph
 pluginName = CodeGraph
 pluginRepositoryUrl = https://github.com/sisimomo/CodeGraph
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.1
+pluginVersion = 0.1.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,10 +11,9 @@
 
     <actions>
         <action id="com.github.sisimomo.codegraph.actions.ShowDependenciesAction"
-                class="com.github.sisimomo.codegraph.actions.ShowDependenciesAction"
-                text="Show Dependencies"
-                description="Display the dependency files (filtered by package) for the current Java file.">
-            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt D"/>
+                class="com.github.sisimomo.codegraph.actions.ShowDependenciesAction">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt G"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
         </action>
     </actions>
 

--- a/src/main/resources/com/github/sisimomo/codegraph/ui/graph.js
+++ b/src/main/resources/com/github/sisimomo/codegraph/ui/graph.js
@@ -59,6 +59,14 @@ class GraphManager {
                 }
             },
             {
+                selector: 'node.root',
+                style: {
+                    'background-color': '#FFA500',
+                    'border-width': 3,
+                    'border-color': '#E67E00'
+                }
+            },
+            {
                 selector: '.node-disabled',
                 style: {
                     'background-color': '#B0BEC5',

--- a/src/main/resources/messages/CodeGraphBundle.properties
+++ b/src/main/resources/messages/CodeGraphBundle.properties
@@ -1,6 +1,8 @@
 dialog.packageFilter.title=Package Filter
 dialog.packageFilter.message=Enter package filter (leave empty for all):
 dialog.noJavaFile.title=No Java File Found
-dialog.noJavaFile.message=Please open a Java file before running this action.
+dialog.noJavaFile.message=Please select Java file(s) before running this action.
 dialog.dependencies.title=Dependencies for {0}
 button.concatenateToClipboard=Concatenate to Clipboard
+dialog.showDependenciesAction.text=CodeGraph - Show Java Dependencies
+dialog.showDependenciesAction.description=Display a dependencies graph for the Java file(s)

--- a/src/main/resources/messages/CodeGraphBundle_fr.properties
+++ b/src/main/resources/messages/CodeGraphBundle_fr.properties
@@ -1,0 +1,8 @@
+dialog.packageFilter.title=Filtre de package
+dialog.packageFilter.message=Entrez le filtre de package (laissez vide pour tout sélectionner) :
+dialog.noJavaFile.title=Aucun Fichier Java Trouvé
+dialog.noJavaFile.message=Veuillez selectionner un/des fichier(s) Java avant d'exécuter cette action.
+dialog.dependencies.title=Dépendances pour {0}
+button.concatenateToClipboard=Concaténer dans le Presse-papiers
+dialog.showDependenciesAction.text=CodeGraph - Afficher les dépendances
+dialog.showDependenciesAction.description=Afficher un graphique des dépendances pour le(s) fichier(s) Java


### PR DESCRIPTION
- Allow selecting multiple Java files in IntelliJ IDEA project panel.
- Update dependency analysis to handle multiple root files.
- Introduce French translations for UI messages.
- Highlight root files in orange for better visibility.
- Modify keyboard shortcut to `Ctrl` + `Alt` + `G`.
- Improve usage instructions in `README.md`.
- Bump plugin version to `0.1.0`.