### PR TITLE
ci(release): update release workflow to comply with PR title linting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,14 +87,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
+          BRANCH="support/changelog-update-$VERSION"
           LABEL="release changelog"
 
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
 
           git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
+          git commit -am "chore: changelog update - $VERSION"
           git push --set-upstream origin $BRANCH
           
           gh label create "$LABEL" \
@@ -103,7 +103,7 @@ jobs:
             || true
 
           gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
+            --title "chore: changelog update - \`$VERSION\`" \
             --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
             --label "$LABEL" \
             --head $BRANCH


### PR DESCRIPTION
- Modify branch naming convention in 'Create Pull Request' step to use 'support/' prefix
- Adjust commit message format to follow Conventional Commits standard
- Update PR title format to ensure compliance with 'lint-pr-title.yml' GitHub Action

Ensures that pull requests created by the release workflow trigger the 'lint-pr-title.yml' action.