### PR TITLE
feat: add Kotlin support and enhance dependency resolution via PSI traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@
 
 ### Added
 
+- Support for selecting and analyzing Kotlin files in addition to Java files.
 - New "Copy AI Agent Context Prompt" action to copy relative file paths instead of file content.
 - File paths in clipboard content are now shown as project-relative instead of just filenames.
+
+### Changed
+
+- Dependency collection is now more intelligent: instead of relying only on import statements, the plugin analyzes
+  actual code references within Java and Kotlin files using PSI traversal. This results in a more accurate and
+  comprehensive dependency graph that reflects better file relationships and usages.
 
 ## [0.1.0] - 2025-02-19
 
@@ -29,7 +36,7 @@
 
 - Initial version
 - Initial scaffold created
-  from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
+  from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intelliJ-platform-plugin-template)
 
 [Unreleased]: https://github.com/sisimomo/CodeGraph/compare/v0.1.0...HEAD
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 <!-- Plugin description -->
 
-This IntelliJ plugin generates an **interactive dependency graph** for a selected Java file, allowing users to **filter
-dependencies** based on a specified package and **concatenate selected files** into the clipboard. The plugin provides a
-visual representation of the dependencies, enabling users to explore and manipulate them interactively.
+This IntelliJ plugin generates an **interactive dependency graph** for selected Java or Kotlin files, allowing users to
+**filter dependencies** based on a specified package and **concatenate selected files** into the clipboard. The plugin
+provides a visual representation of the dependencies, enabling users to explore and manipulate them interactively.
 
 ## Usage
 
-1. **Select one or multiples Java file** in IntelliJ IDEA project side panel.
+1. **Select one or multiple Java or Kotlin files** in the IntelliJ IDEA project side panel.
 2. **Invoke the plugin** using the configured shortcut (default <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd>).
     - Or use the Command Palette (Find Action, <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd>) then type <kbd>
       CodeGraph - Show Dependencies</kbd>.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,8 @@ dependencies {
         create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
 
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
-        bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })
+        bundledPlugins(
+            providers.gradleProperty("platformBundledPlugins").map { it.split(',') + "org.jetbrains.kotlin" })
 
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })

--- a/src/main/kotlin/com/github/sisimomo/codegraph/ui/DependenciesDialog.kt
+++ b/src/main/kotlin/com/github/sisimomo/codegraph/ui/DependenciesDialog.kt
@@ -6,7 +6,7 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
-import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiFile
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
@@ -25,12 +25,12 @@ import javax.swing.SwingUtilities
 
 class DependenciesDialog(
     private val project: Project,
-    private val rootFiles: List<PsiJavaFile>,
-    private val dependencyGraph: Map<PsiJavaFile, List<PsiJavaFile>>
+    private val rootFiles: List<PsiFile>,
+    private val dependencyGraph: Map<PsiFile, List<PsiFile>>
 ) : DialogWrapper(project, false) {
 
     private val disabledNodes = mutableSetOf<String>()
-    private val fileToId = mutableMapOf<PsiJavaFile, String>()
+    private val fileToId = mutableMapOf<PsiFile, String>()
     private val objectMapper = jacksonObjectMapper()
 
     companion object {
@@ -116,7 +116,7 @@ class DependenciesDialog(
 
     private fun assignFileIds() {
         var idCounter = 1
-        fun getId(file: PsiJavaFile) = fileToId.getOrPut(file) { "node_${idCounter++}" }
+        fun getId(file: PsiFile) = fileToId.getOrPut(file) { "node_${idCounter++}" }
 
         rootFiles.forEach(::getId)  // Assign IDs to all root files
         dependencyGraph.keys.forEach(::getId)
@@ -203,13 +203,13 @@ class DependenciesDialog(
         CopyPasteManager.getInstance().setContents(StringSelection(prompt.trim()))
     }
 
-    private fun getEnabledFiles(): List<PsiJavaFile> {
+    private fun getEnabledFiles(): List<PsiFile> {
         return fileToId.entries
             .filterNot { disabledNodes.contains(it.value) }
             .map { it.key }
     }
 
-    private fun buildAiPrompt(files: List<PsiJavaFile>): String {
+    private fun buildAiPrompt(files: List<PsiFile>): String {
         return buildString {
             appendLine(CodeGraphBundle.message("button.aiPromptToClipboard.prompt"))
             files.forEach { file ->
@@ -218,7 +218,7 @@ class DependenciesDialog(
         }
     }
 
-    private fun getRelativePath(file: PsiJavaFile): String {
+    private fun getRelativePath(file: PsiFile): String {
         val vFile = file.virtualFile
         return vFile?.let {
             project.basePath.let { base ->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>  <!-- Java support added here -->
+    <depends>org.jetbrains.kotlin</depends>  <!-- Added Kotlin plugin dependency for Kotlin PSI support -->
 
     <resource-bundle>messages.CodeGraphBundle</resource-bundle>
 

--- a/src/main/resources/messages/CodeGraphBundle.properties
+++ b/src/main/resources/messages/CodeGraphBundle.properties
@@ -1,10 +1,10 @@
 dialog.packageFilter.title=Package Filter
 dialog.packageFilter.message=Enter package filter (leave empty for all):
-dialog.noJavaFile.title=No Java File Found
-dialog.noJavaFile.message=Please select Java file(s) before running this action.
+dialog.noJavaKotlinFile.title=No Java/Kotlin File Found
+dialog.noJavaKotlinFile.message=Please select Java/Kotlin file(s) before running this action.
 dialog.dependencies.title=Dependencies for {0}
 button.concatenateToClipboard=Concatenate to Clipboard
-dialog.showDependenciesAction.text=CodeGraph - Show Java Dependencies
-dialog.showDependenciesAction.description=Display a dependencies graph for the Java file(s)
+dialog.showDependenciesAction.text=CodeGraph - Show Java/Kotlin Dependencies
+dialog.showDependenciesAction.description=Display a dependencies graph for the Java/Kotlin file(s)
 button.aiPromptToClipboard.label=Copy AI Agent Context Prompt
 button.aiPromptToClipboard.prompt=Use the following files as context for my next requests:

--- a/src/main/resources/messages/CodeGraphBundle_fr.properties
+++ b/src/main/resources/messages/CodeGraphBundle_fr.properties
@@ -1,10 +1,10 @@
 dialog.packageFilter.title=Filtre de package
 dialog.packageFilter.message=Entrez le filtre de package (laissez vide pour tout sélectionner) :
-dialog.noJavaFile.title=Aucun Fichier Java Trouvé
-dialog.noJavaFile.message=Veuillez selectionner un/des fichier(s) Java avant d'exécuter cette action.
+dialog.noJavaKotlinFile.title=Aucun Fichier Java/Kotlin Trouvé
+dialog.noJavaKotlinFile.message=Veuillez selectionner un/des fichier(s) Java/Kotlin avant d'exécuter cette action.
 dialog.dependencies.title=Dépendances pour {0}
 button.concatenateToClipboard=Concaténer dans le Presse-papiers
 dialog.showDependenciesAction.text=CodeGraph - Afficher les dépendances
-dialog.showDependenciesAction.description=Afficher un graphique des dépendances pour le(s) fichier(s) Java
+dialog.showDependenciesAction.description=Afficher un graphique des dépendances pour le(s) fichier(s) Java/Kotlin
 button.aiPromptToClipboard.label=Copier le prompt de contexte pour l'agent IA
 button.aiPromptToClipboard.prompt=Utilise les fichiers suivants comme contexte pour mes futures requêtes :


### PR DESCRIPTION
Extend plugin functionality to support Kotlin files alongside Java. Improve dependency graph accuracy by analyzing actual code references using PSI traversal, rather than relying solely on import statements. Update UI labels and plugin metadata accordingly.