### PR TITLE
fix: declare compatibility with Kotlin K2 mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Explicitly declare compatibility with Kotlin K2 mode by adding to resolve plugin incompatibility warning.
+
 ## [0.2.0] - 2025-06-29
 
 ### Added
@@ -41,6 +45,9 @@
   from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intelliJ-platform-plugin-template)
 
 [Unreleased]: https://github.com/sisimomo/CodeGraph/compare/v0.2.0...HEAD
+
 [0.2.0]: https://github.com/sisimomo/CodeGraph/compare/v0.1.0...v0.2.0
+
 [0.1.0]: https://github.com/sisimomo/CodeGraph/compare/v0.0.1...v0.1.0
+
 [0.0.1]: https://github.com/sisimomo/CodeGraph/commits/v0.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.sisimomo.codegraph
 pluginName = CodeGraph
 pluginRepositoryUrl = https://github.com/sisimomo/CodeGraph
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.0
+pluginVersion = 0.2.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,4 +18,8 @@
         </action>
     </actions>
 
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true"/>
+    </extensions>
+
 </idea-plugin>


### PR DESCRIPTION
add <supportsKotlinPluginMode supportsK2="true"/> to explicitly declare compatibility with Kotlin K2 mode and resolve plugin incompatibility warning